### PR TITLE
Check for updates and download from Github

### DIFF
--- a/ModManager/modManager.cs
+++ b/ModManager/modManager.cs
@@ -68,11 +68,11 @@ namespace ModManager
 
                 using (WebClient client = new WebClient())
                 {
-                	//Add a User-Agent since GitHub returns 403 on the default
-                	client.Headers.Add("User-Agent", "Among Us ModManager");
-                	string githubResponse = client.DownloadString("https://api.github.com/repos/MatuxGG/ModManager/releases/latest");
-                	JObject parsedResponse = JObject.Parse(githubResponse);
-                	string version = (string)parsedResponse["tag_name"];
+                    //Add a User-Agent since GitHub returns 403 on the default
+                    client.Headers.Add("User-Agent", "Among Us ModManager");
+                    string githubResponse = client.DownloadString("https://api.github.com/repos/MatuxGG/ModManager/releases/latest");
+                    JObject parsedResponse = JObject.Parse(githubResponse);
+                    string version = (string)parsedResponse["tag_name"];
                     if (Version.Parse(version) > curVersion)
                     {
                         if (MessageBox.Show("There is a new version of Mod Manager available, would you like to download it ?", "Mod Manager Update", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)

--- a/ModManager/modManager.cs
+++ b/ModManager/modManager.cs
@@ -68,7 +68,11 @@ namespace ModManager
 
                 using (WebClient client = new WebClient())
                 {
-                    string version = client.DownloadString(this.serverURL + "/version.txt");
+                	//Add a User-Agent since GitHub returns 403 on the default
+                	client.Headers.Add("User-Agent", "Among Us ModManager");
+                	string githubResponse = client.DownloadString("https://api.github.com/repos/MatuxGG/ModManager/releases/latest");
+                	JObject parsedResponse = JObject.Parse(githubResponse);
+                	string version = (string)parsedResponse["tag_name"];
                     if (Version.Parse(version) > curVersion)
                     {
                         if (MessageBox.Show("There is a new version of Mod Manager available, would you like to download it ?", "Mod Manager Update", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
@@ -78,7 +82,7 @@ namespace ModManager
                             {
                                 this.utils.FileDelete(this.appPath + "\\ModManagerInstaller.exe");
                             }
-                            client.DownloadFile(this.serverURL + "/ModManagerInstaller.exe", this.appPath + "\\ModManagerInstaller.exe");
+                            client.DownloadFile((string)parsedResponse["assets"][1]["browser_download_url"], this.appPath + "\\ModManagerInstaller.exe");
                             Process.Start(this.appPath + "\\ModManagerInstaller.exe");
                             Environment.Exit(0);
                         }


### PR DESCRIPTION
This replaces downloading from your website to downloading from Github releases. It should make downloading faster, more reliable and more secure since Github is probably more secure than your webserver. Also it allows the opportunity to include a changelog in the update window, which you should just be able to read with `parsedResponse["body"]`, however I don't know a lot about C# GUI so I didn't implement it.

As it currently is however, it expects the installer exe to always be the second file uploaded to the release. This has always been the case for every release in over a month, however you may want to implement some logic to select the correct file if you want to go the safe route. Should only have to check whether `parsedResponse["assets"][1]["browser_download_url"]` or `parsedResponse["assets"][0]["browser_download_url"]` ends on .exe

As a sidenode, please test this thoroughly. I don't use windows personally so I could only test this on a VM.
If you have any nits, please let me know or edit them yourself.